### PR TITLE
Become binary-safe. Now works on (and returns) buffers

### DIFF
--- a/lib/thirty-two/thirty-two.js
+++ b/lib/thirty-two/thirty-two.js
@@ -44,18 +44,21 @@ exports.encode = function(plain) {
     var j = 0;
     var shiftIndex = 0;
     var digit = 0;
-    var encoded = new Array(quintetCount(plain) * 8);    
+    var encoded = new Buffer(quintetCount(plain) * 8);
+    if(!Buffer.isBuffer(plain)){
+    	plain = new Buffer(plain);
+    }
 
     /* byte by byte isn't as pretty as quintet by quintet but tests a bit
         faster. will have to revisit. */
     while(i < plain.length) {
-        var current = plain.charCodeAt(i);
+        var current = plain[i];
     
         if(shiftIndex > 3) {
             digit = current & (0xff >> shiftIndex);
             shiftIndex = (shiftIndex + 5) % 8;
             digit = (digit << shiftIndex) | ((i + 1 < plain.length) ?
-                plain.charCodeAt(i + 1) : 0) >> (8 - shiftIndex);
+                plain[i + 1] : 0) >> (8 - shiftIndex);
             i++;
         } else {
             digit = (current >> (8 - (shiftIndex + 5))) & 0x1f;
@@ -63,14 +66,14 @@ exports.encode = function(plain) {
             if(shiftIndex == 0) i++;
         }
         
-        encoded[j] = charTable[digit];
+        encoded[j] = charTable.charCodeAt(digit);
         j++;
     }
 
     for(i = j; i < encoded.length; i++)
-        encoded[i] = '=';
+        encoded[i] = 0x3d; //'='.charCodeAt(0)
         
-    return encoded.join('');
+    return encoded;
 };
 
 exports.decode = function(encoded) {
@@ -78,14 +81,19 @@ exports.decode = function(encoded) {
     var plainDigit = 0;
     var plainChar;
     var plainPos = 0;
-    
-    encoded = encoded.replace(/[=]+$/, '');
-    var decoded = new Array(Math.floor(encoded.length * 5 / 8));
+    if(!Buffer.isBuffer(encoded)){
+    	encoded = new Buffer(encoded);
+    }
+    var decoded = new Buffer(Math.ceil(encoded.length * 5 / 8));
     
     /* byte by byte isn't as pretty as octet by octet but tests a bit
         faster. will have to revisit. */    
     for(var i = 0; i < encoded.length; i++) {
-        var encodedByte = encoded.charCodeAt(i) - 0x30;
+    	if(encoded[i] == 0x3d){ //'='
+    		break;
+    	}
+    		
+        var encodedByte = encoded[i] - 0x30;
         
         if(encodedByte < byteTable.length) {
             plainDigit = byteTable[encodedByte];
@@ -95,7 +103,7 @@ exports.decode = function(encoded) {
                 
                 if(shiftIndex == 0) {
                     plainChar |= plainDigit;
-                    decoded[plainPos] = String.fromCharCode(plainChar);
+                    decoded[plainPos] = plainChar;
                     plainPos++;
                     plainChar = 0;
                 } else {
@@ -104,13 +112,14 @@ exports.decode = function(encoded) {
             } else {
                 shiftIndex = (shiftIndex + 5) % 8;
                 plainChar |= 0xff & (plainDigit >>> shiftIndex);
-                decoded[plainPos] = String.fromCharCode(plainChar);
+                decoded[plainPos] = plainChar;
                 plainPos++;
 
                 plainChar = 0xff & (plainDigit << (8 - shiftIndex));
             }
+        } else {
+        	throw new Error('Invalid input - it is not base32 encoded string');
         }
     }
-
-    return decoded.join('');
+    return decoded.slice(0, plainPos);
 };

--- a/spec/thirty-two_spec.js
+++ b/spec/thirty-two_spec.js
@@ -19,29 +19,45 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN       
 THE SOFTWARE.                                                                   
 */
-
-var base32 = require('lib/thirty-two/');
+if(!expect){
+	function expect(a){
+		return {
+			toBe: function(b){
+				require('assert').strictEqual(a, b);
+			}
+		};
+	}
+}
+var base32 = require('../lib/thirty-two/');
 
 describe('thirty-two', function() {
     it('should encode', function() {
-        expect(base32.encode('a')).toBe('ME======');
-        expect(base32.encode('be')).toBe('MJSQ====');
-        expect(base32.encode('bee')).toBe('MJSWK===');
-        expect(base32.encode('beer')).toBe('MJSWK4Q=');
-        expect(base32.encode('beers')).toBe('MJSWK4TT');
-        expect(base32.encode('beers 1')).toBe('MJSWK4TTEAYQ====');
-        expect(base32.encode('shockingly dismissed')).toBe('ONUG6Y3LNFXGO3DZEBSGS43NNFZXGZLE');        
+        expect(base32.encode('a').toString()).toBe('ME======');
+        expect(base32.encode('be').toString()).toBe('MJSQ====');
+        expect(base32.encode('bee').toString()).toBe('MJSWK===');
+        expect(base32.encode('beer').toString()).toBe('MJSWK4Q=');
+        expect(base32.encode('beers').toString()).toBe('MJSWK4TT');
+        expect(base32.encode('beers 1').toString()).toBe('MJSWK4TTEAYQ====');
+        expect(base32.encode('shockingly dismissed').toString()).toBe('ONUG6Y3LNFXGO3DZEBSGS43NNFZXGZLE');        
     });
     
+    
     it('should decode', function() {
-        expect(base32.decode('ME======')).toBe('a');
-        expect(base32.decode('MJSQ====')).toBe('be');
-        expect(base32.decode('ONXW4===')).toBe('son');
-        expect(base32.decode('MJSWK===')).toBe('bee');
-        expect(base32.decode('MJSWK4Q=')).toBe('beer');
-        expect(base32.decode('MJSWK4TT')).toBe('beers');
-        expect(base32.decode('MJSWK4TTN5XA====')).toBe('beerson');
-        expect(base32.decode('MJSWK4TTEAYQ====')).toBe('beers 1');
-        expect(base32.decode('ONUG6Y3LNFXGO3DZEBSGS43NNFZXGZLE')).toBe('shockingly dismissed');
+        expect(base32.decode('ME======').toString()).toBe('a');
+        expect(base32.decode('MJSQ====').toString()).toBe('be');
+        expect(base32.decode('ONXW4===').toString()).toBe('son');
+        expect(base32.decode('MJSWK===').toString()).toBe('bee');
+        expect(base32.decode('MJSWK4Q=').toString()).toBe('beer');
+        expect(base32.decode('MJSWK4TT').toString()).toBe('beers');
+        expect(base32.decode('mjswK4TT').toString()).toBe('beers');
+        expect(base32.decode('MJSWK4TTN5XA====').toString()).toBe('beerson');
+        expect(base32.decode('MJSWK4TTEAYQ====').toString()).toBe('beers 1');
+        expect(base32.decode('ONUG6Y3LNFXGO3DZEBSGS43NNFZXGZLE').toString()).toBe('shockingly dismissed');
+    });
+    
+    it('should be binary safe', function() {
+        expect(base32.decode(base32.encode(new Buffer([0x00, 0xff, 0x88]))).toString('hex')).toBe('00ff88');
+    	expect(base32.encode(new Buffer("f61e1f998d69151de8334dbe753ab17ae831c13849a6aecd95d0a4e5dc25", 'hex')).toString()).toBe('6YPB7GMNNEKR32BTJW7HKOVRPLUDDQJYJGTK5TMV2CSOLXBF');
+    	expect(base32.decode('6YPB7GMNNEKR32BTJW7HKOVRPLUDDQJYJGTK5TMV2CSOLXBF').toString('hex')).toBe('f61e1f998d69151de8334dbe753ab17ae831c13849a6aecd95d0a4e5dc25');
     });
 });


### PR DESCRIPTION
Commit that makes thirty-two binary safe. Solves some problems with encoding unprintable characters, which to be honest is what base-(whatever) is for.

Somewhat not backward compatible. Encode and decode will still accept strings, but will now return buffers.
