### PR TITLE
Added repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,5 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/chrisumbel/thirty-two.git"
-  },
+  }
 }


### PR DESCRIPTION
When currently installing the package, npm will warn "npm WARN package.json thirty-two@0.0.1 No repository field.". This resolves that warning.

A new version should probably be published after this change.
