### PR TITLE
bugfix: support utf8 strings

### DIFF
--- a/lib/thirty-two/thirty-two.js
+++ b/lib/thirty-two/thirty-two.js
@@ -40,14 +40,14 @@ function quintetCount(buff) {
 }
 
 exports.encode = function(plain) {
+    if(!Buffer.isBuffer(plain)){
+    	plain = new Buffer(plain);
+    }
     var i = 0;
     var j = 0;
     var shiftIndex = 0;
     var digit = 0;
     var encoded = new Buffer(quintetCount(plain) * 8);
-    if(!Buffer.isBuffer(plain)){
-    	plain = new Buffer(plain);
-    }
 
     /* byte by byte isn't as pretty as quintet by quintet but tests a bit
         faster. will have to revisit. */


### PR DESCRIPTION
The converting a non-buffer to a buffer must happen before the byte length count is attempted, otherwise you break utf8 strings (or any non-uint8arrays).