### PR TITLE
update misleading for loop and if

### DIFF
--- a/lib/thirty-two/thirty-two.js
+++ b/lib/thirty-two/thirty-two.js
@@ -63,15 +63,16 @@ exports.encode = function(plain) {
         } else {
             digit = (current >> (8 - (shiftIndex + 5))) & 0x1f;
             shiftIndex = (shiftIndex + 5) % 8;            
-            if(shiftIndex == 0) i++;
+            if(shiftIndex == 0) { i++; }
         }
         
         encoded[j] = charTable.charCodeAt(digit);
         j++;
     }
 
-    for(i = j; i < encoded.length; i++)
+    for(i = j; i < encoded.length; i++) {
         encoded[i] = 0x3d; //'='.charCodeAt(0)
+    }
         
     return encoded;
 };


### PR DESCRIPTION
The for loop here is missing brackets, but still uses indentation, which can be misleading to the reader / editor.

Although it isn't particularly misleading, I also added brackets around the one-line if for consistency.