### PR TITLE
use semver for versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thirty-two",
   "description": "Implementation RFC 3548 Base32 encoding/decoding for node.",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "engines": {
     "node": ">=0.2.6"
   },


### PR DESCRIPTION
0.0.2 isn't a meaningful semver for production code.

A well-published library such as this should start at 1.0.0 (and could include a pre release build suffix such as 1.0.0-alpha or 1.0.0-rc1).

Since this is a pretty simple library and has been rather "stable", it makes sense to bump it straight to 1.0.0 without any -alpha or -beta or -rc1 type suffixes.