### PR TITLE
Add license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=0.2.6"
   },
   "author": "Chris Umbel <chris@chrisumbel.com>",
+  "license": "MIT",
   "keywords": ["base32", "encoding"],
   "main": "./lib/thirty-two/index.js",
   "repository": {


### PR DESCRIPTION
Adding the "license" info to package.json, following the syntax in https://docs.npmjs.com/files/package.json#license .