### PR TITLE
Remove unnecessary quintetCount function

### DIFF
--- a/lib/thirty-two/index.js
+++ b/lib/thirty-two/index.js
@@ -34,10 +34,6 @@ var byteTable = [
     0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
     0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff
 ];
-function quintetCount(buff) {
-    var quintets = Math.floor(buff.length / 5);
-    return buff.length % 5 === 0 ? quintets : quintets + 1;
-}
 var encode = function (plain) {
     if (!Buffer.isBuffer(plain) && typeof plain !== "string") {
         throw new TypeError("base32.encode only takes Buffer or string as parameter");
@@ -49,7 +45,7 @@ var encode = function (plain) {
     var j = 0;
     var shiftIndex = 0;
     var digit = 0;
-    var encoded = Buffer.alloc(quintetCount(plain) * 8);
+    var encoded = Buffer.alloc(Math.ceil(plain.length / 5));
     /* byte by byte isn't as pretty as quintet by quintet but tests a bit
         faster. will have to revisit. */
     while (i < plain.length) {


### PR DESCRIPTION
Since the function is used only once and does the same as `Math.ceil`, I think is better to remove the function and directly calculate the quintet count using `Math.ceil`.