### PR TITLE
fix: drop buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.kpf
 *~
 \#*
-node_modules
+node_modules/
+package-lock.json

--- a/lib/thirty-two/index.js
+++ b/lib/thirty-two/index.js
@@ -1,3 +1,4 @@
+import { text2arr } from 'uint8-util'
 /*
 Copyright (c) 2011, Chris Umbel
 
@@ -19,10 +20,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-'use strict';
-exports.__esModule = true;
-var charTable = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-var byteTable = [
+const charTable = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const byteTable = [
     0xff, 0xff, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
@@ -34,66 +33,65 @@ var byteTable = [
     0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
     0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff
 ];
-function quintetCount(buff) {
-    var quintets = Math.floor(buff.length / 5);
+function quintetCount (buff) {
+    const quintets = Math.floor(buff.length / 5);
     return buff.length % 5 === 0 ? quintets : quintets + 1;
 }
-var encode = function (plain) {
-    if (!Buffer.isBuffer(plain) && typeof plain !== "string") {
-        throw new TypeError("base32.encode only takes Buffer or string as parameter");
+const encode = function (plain) {
+    if (!ArrayBuffer.isView(plain) && typeof plain !== 'string') {
+        throw new TypeError('base32.encode only takes Buffer or string as parameter');
     }
-    if (!Buffer.isBuffer(plain)) {
-        plain = Buffer.from(plain);
+    if (!ArrayBuffer.isView(plain)) {
+        plain = text2arr(plain);
     }
-    var i = 0;
-    var j = 0;
-    var shiftIndex = 0;
-    var digit = 0;
-    var encoded = Buffer.alloc(quintetCount(plain) * 8);
+    let i = 0;
+    let j = 0;
+    let shiftIndex = 0;
+    let digit = 0;
+    const encoded = new Uint8Array(quintetCount(plain) * 8);
     /* byte by byte isn't as pretty as quintet by quintet but tests a bit
         faster. will have to revisit. */
     while (i < plain.length) {
-        var current = plain[i];
+        const current = plain[i];
         if (shiftIndex > 3) {
             digit = current & (0xff >> shiftIndex);
             shiftIndex = (shiftIndex + 5) % 8;
-            digit = (digit << shiftIndex) | ((i + 1 < plain.length) ?
-                plain[i + 1] : 0) >> (8 - shiftIndex);
+            digit = (digit << shiftIndex) | ((i + 1 < plain.length)
+                ? plain[i + 1]
+                : 0) >> (8 - shiftIndex);
             i++;
-        }
-        else {
+        } else {
             digit = (current >> (8 - (shiftIndex + 5))) & 0x1f;
             shiftIndex = (shiftIndex + 5) % 8;
-            if (shiftIndex === 0)
-                i++;
+            if (shiftIndex === 0) { i++; }
         }
         encoded[j] = charTable.charCodeAt(digit);
         j++;
     }
     for (i = j; i < encoded.length; i++) {
-        encoded[i] = 0x3d; //'='.charCodeAt(0)
+        encoded[i] = 0x3d; // '='.charCodeAt(0)
     }
     return encoded;
 };
-var decode = function (encoded) {
-    if (!Buffer.isBuffer(encoded) && typeof encoded !== "string") {
-        throw new TypeError("base32.decode only takes Buffer or string as parameter");
+const decode = function (encoded) {
+    if (!ArrayBuffer.isView(encoded) && typeof encoded !== 'string') {
+        throw new TypeError('base32.decode only takes Buffer or string as parameter');
     }
-    var shiftIndex = 0;
-    var plainDigit = 0;
-    var plainChar;
-    var plainPos = 0;
-    if (!Buffer.isBuffer(encoded)) {
-        encoded = Buffer.from(encoded);
+    let shiftIndex = 0;
+    let plainDigit = 0;
+    let plainChar;
+    let plainPos = 0;
+    if (!ArrayBuffer.isView(encoded)) {
+        encoded = text2arr(encoded);
     }
-    var decoded = Buffer.alloc(Math.ceil(encoded.length * 5 / 8));
+    const decoded = new Uint8Array(Math.ceil(encoded.length * 5 / 8));
     /* byte by byte isn't as pretty as octet by octet but tests a bit
         faster. will have to revisit. */
-    for (var i = 0; i < encoded.length; i++) {
-        if (encoded[i] === 0x3d) { //'='
+    for (let i = 0; i < encoded.length; i++) {
+        if (encoded[i] === 0x3d) { // '='
             break;
         }
-        var encodedByte = encoded[i] - 0x30;
+        const encodedByte = encoded[i] - 0x30;
         if (encodedByte < byteTable.length) {
             plainDigit = byteTable[encodedByte];
             if (shiftIndex <= 3) {
@@ -103,23 +101,21 @@ var decode = function (encoded) {
                     decoded[plainPos] = plainChar;
                     plainPos++;
                     plainChar = 0;
-                }
-                else {
+                } else {
                     plainChar |= 0xff & (plainDigit << (8 - shiftIndex));
                 }
-            }
-            else {
+            } else {
                 shiftIndex = (shiftIndex + 5) % 8;
                 plainChar |= 0xff & (plainDigit >>> shiftIndex);
                 decoded[plainPos] = plainChar;
                 plainPos++;
                 plainChar = 0xff & (plainDigit << (8 - shiftIndex));
             }
-        }
-        else {
+        } else {
             throw new Error('Invalid input - it is not base32 encoded string');
         }
     }
-    return decoded.slice(0, plainPos);
+    return decoded.subarray(0, plainPos);
 };
-exports["default"] = { encode: encode, decode: decode };
+export default { encode, decode };
+export { encode, decode };

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "thirty-two",
   "description": "Implementation RFC 3548 Base32 encoding/decoding for node.",
   "version": "1.0.3",
+  "type": "module",
   "engines": {
     "node": ">=0.2.6"
   },
@@ -13,5 +14,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/chrisumbel/thirty-two.git"
+  },
+  "dependencies": {
+    "uint8-util": "^2.1.9"
   }
 }


### PR DESCRIPTION
this PR drops buffer, and instead uses uint8, also migrates to ESM, it imports a new dependency, but as it uses ESM as well, its fully tree shake-able for the single function we import from it

if FSA is unsupported we fallback to memory, so 12% of userbase will use memory